### PR TITLE
Move duration method to event adapter

### DIFF
--- a/boundaries/infra/adapters/event.rb
+++ b/boundaries/infra/adapters/event.rb
@@ -14,6 +14,12 @@ module Boundaries
           !!(event.summary =~ /refining/i)
         end
 
+        def duration
+          return 0 if event.end.date_time.nil?
+
+          (event.end.date_time - event.start.date_time).to_f * 24
+        end
+
         private
 
         attr_reader :event

--- a/main.rb
+++ b/main.rb
@@ -1,5 +1,4 @@
 require 'google/apis/calendar_v3'
-require './boundaries/infra/authorization'
 require './boundaries/infra/gateway'
 
 events = Boundaries::Infra::Gateway.new.list_events
@@ -8,6 +7,5 @@ puts 'Upcoming events:'
 puts 'No upcoming events found' if events.empty?
 
 events.each do |event|
-  duration = (event.end.date_time - event.start.date_time).to_f * 24
-  puts "- #{event.summary} (#{duration}) #{event.refining?}"
+  puts "- #{event.summary} (#{event.duration}) #{event.refining?}"
 end


### PR DESCRIPTION
In the future, I could use Whole Value Pattern. For now, I think it is ok to consider duration in hours as default.